### PR TITLE
Feat/todolist 모달 중복 생성 버그 개선

### DIFF
--- a/JS/todolist/todolist.js
+++ b/JS/todolist/todolist.js
@@ -117,6 +117,9 @@ export function todolist() {
 
         // 확인 모달을 띄워서 사용자의 확인을 받은 뒤, `onConfirm()`을 실행
         function createConfirmModal(onConfirm) {
+            if (document.getElementById('confirmModal')) {
+                return;
+            }
             const $confirmModal = document.createElement('div');
             $confirmModal.id = 'confirmModal';
             $confirmModal.className = 'modal-overlay-internal';


### PR DESCRIPTION
모달 생성 로직이 업데이트

- 모달을 생성하기 전에 기존 "confirmModal"을 확인하여 모달 오버레이 및 모달이 중복 생성하는 것을 방지합니다.


관련이슈 #49 
관련 브랜츠 feat/todolist